### PR TITLE
How

### DIFF
--- a/src/components/how/hero/Hero.module.sass
+++ b/src/components/how/hero/Hero.module.sass
@@ -28,7 +28,7 @@
     position: relative
     z-index: 3
     +m
-        margin-bottom: 80px
+        margin-bottom: 40px
     h1
         max-width: 200px
         +s
@@ -75,7 +75,6 @@
         position: relative
         img
             object-fit: contain
-
-        +s
+        +d
             height: 300px
     


### PR DESCRIPTION
- Changed hero image margin-bottom
- Modified hero image height for screen sizes from 1159px to mobile view